### PR TITLE
Rename module to Control.Monad.Eff.Console

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -5,6 +5,8 @@
     "beforeOpeningRoundBrace": true,
     "beforeOpeningCurlyBrace": true
   },
+  "disallowSpacesInsideObjectBrackets": null,
+  "requireSpacesInsideObjectBrackets": "all",
   "validateQuoteMarks": "\"",
   "requireCurlyBraces": null
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/purescript/purescript-console.svg?branch=master)](https://travis-ci.org/purescript/purescript-console)
 
-Console-related functions. For use with compiler version >= 0.7.
+Console-related functions and effect type.
 
 ## Installation
 
@@ -10,6 +10,8 @@ Console-related functions. For use with compiler version >= 0.7.
 bower install purescript-console
 ```
 
+This library requires PureScript 0.7 or later.
+
 ## Module documentation
 
-- [Console](docs/Console.md)
+- [Control.Monad.Eff.Console](docs/Control.Monad.Eff.Console.md)

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,10 @@
 {
   "name": "purescript-console",
   "homepage": "https://github.com/purescript/purescript-console",
-  "description": "Console-related functions",
+  "description": "Console-related functions and effect type for PureScript.",
   "keywords": [
-    "purescript"
+    "purescript",
+    "console"
   ],
   "license": "MIT",
   "repository": {

--- a/docs/Control.Monad.Eff.Console.md
+++ b/docs/Control.Monad.Eff.Console.md
@@ -1,0 +1,35 @@
+## Module Control.Monad.Eff.Console
+
+#### `CONSOLE`
+
+``` purescript
+data CONSOLE :: !
+```
+
+The `CONSOLE` effect represents those computations which write to the console.
+
+#### `log`
+
+``` purescript
+log :: forall eff. String -> Eff (console :: CONSOLE | eff) Unit
+```
+
+Write a message to the console.
+
+#### `error`
+
+``` purescript
+error :: forall eff. String -> Eff (console :: CONSOLE | eff) Unit
+```
+
+Write an error to the console.
+
+#### `print`
+
+``` purescript
+print :: forall a eff. (Show a) => a -> Eff (console :: CONSOLE | eff) Unit
+```
+
+Write a value to the console, using its `Show` instance to produce a `String`.
+
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,7 @@ gulp.task("docs", function () {
     .pipe(plumber())
     .pipe(purescript.pscDocs({
       docgen: {
-        "Console": "docs/Console.md"
+        "Control.Monad.Eff.Console": "docs/Control.Monad.Eff.Console.md"
       }
     }));
 });

--- a/src/Control/Monad/Eff/Console.js
+++ b/src/Control/Monad/Eff/Console.js
@@ -1,7 +1,7 @@
 /* global exports, console */
 "use strict";
 
-// module Console
+// module Control.Monad.Eff.Console
 
 exports.log = function (s) {
   return function () {

--- a/src/Control/Monad/Eff/Console.purs
+++ b/src/Control/Monad/Eff/Console.purs
@@ -1,4 +1,4 @@
-module Console where
+module Control.Monad.Eff.Console where
 
 import Prelude
 


### PR DESCRIPTION
This would be more in line with `Exception`, etc. what do you think @paf31?
