### PR TITLE
Printing runtime representation of a value

### DIFF
--- a/docs/Control/Monad/Eff/Console.md
+++ b/docs/Control/Monad/Eff/Console.md
@@ -1,5 +1,7 @@
 ## Module Control.Monad.Eff.Console
 
+Console-related functions and effect type.
+
 #### `CONSOLE`
 
 ``` purescript

--- a/docs/Control/Monad/Eff/Console/Unsafe.md
+++ b/docs/Control/Monad/Eff/Console/Unsafe.md
@@ -1,0 +1,21 @@
+## Module Control.Monad.Eff.Console.Unsafe
+
+Unsafe functions to display arbitrary values.
+
+#### `logAny`
+
+``` purescript
+logAny :: forall a eff. a -> Eff (console :: CONSOLE | eff) Unit
+```
+
+Write an arbitrary value to the console.
+
+#### `errorAny`
+
+``` purescript
+errorAny :: forall a eff. a -> Eff (console :: CONSOLE | eff) Unit
+```
+
+Write an error with an arbitrary value to the console.
+
+

--- a/src/Control/Monad/Eff/Console.purs
+++ b/src/Control/Monad/Eff/Console.purs
@@ -1,3 +1,4 @@
+-- | Console-related functions and effect type.
 module Control.Monad.Eff.Console where
 
 import Prelude

--- a/src/Control/Monad/Eff/Console/Unsafe.js
+++ b/src/Control/Monad/Eff/Console/Unsafe.js
@@ -1,0 +1,18 @@
+/* global exports, console */
+"use strict";
+
+// module Control.Monad.Eff.Console.Unsafe
+
+exports.logAny = function (s) {
+  return function () {
+    console.log(s);
+    return {};
+  };
+};
+
+exports.errorAny = function (s) {
+  return function () {
+    console.error(s);
+    return {};
+  };
+};

--- a/src/Control/Monad/Eff/Console/Unsafe.purs
+++ b/src/Control/Monad/Eff/Console/Unsafe.purs
@@ -1,0 +1,13 @@
+-- | Unsafe functions to display arbitrary values.
+module Control.Monad.Eff.Console.Unsafe where
+
+import Prelude
+
+import Control.Monad.Eff
+import Control.Monad.Eff.Console (CONSOLE())
+
+-- | Write an arbitrary value to the console.
+foreign import logAny :: forall a eff. a -> Eff (console :: CONSOLE | eff) Unit
+
+-- | Write an error with an arbitrary value to the console.
+foreign import errorAny :: forall a eff. a -> Eff (console :: CONSOLE | eff) Unit


### PR DESCRIPTION
I find that sometimes I need to do things like:

``` purescript
log $ unsafeCoerce { foo: bar, baz: qux }
```

Might be useful to have a function for that, what do you think?

It feels kind of wrong to have `forall a. a -> ....`. Perhaps it would make sense to put it into Unsafe module. On the other hand I can't come up with a case where doing `console.log(something)` would nuke anyone.
