### PR TITLE
Add console.table

### DIFF
--- a/src/Effect/Class/Console.purs
+++ b/src/Effect/Class/Console.purs
@@ -30,6 +30,9 @@ info = liftEffect <<< EffConsole.info
 infoShow :: forall m a. MonadEffect m => Show a => a -> m Unit
 infoShow = liftEffect <<< EffConsole.infoShow
 
+table :: forall m a. MonadEffect m => a -> m Unit
+table = liftEffect <<< EffConsole.table
+
 time :: forall m. MonadEffect m => String -> m Unit
 time = liftEffect <<< EffConsole.time
 

--- a/src/Effect/Console.js
+++ b/src/Effect/Console.js
@@ -28,6 +28,13 @@ exports.info = function (s) {
   };
 };
 
+exports.table = function (s) {
+  return function () {
+    console.table(s);
+    return {};
+  };
+};
+
 exports.time = function (s) {
   return function () {
     console.time(s);

--- a/src/Effect/Console.purs
+++ b/src/Effect/Console.purs
@@ -45,6 +45,12 @@ foreign import info
 infoShow :: forall a. Show a => a -> Effect Unit
 infoShow a = info (show a)
 
+-- | Write an tabular data to the console as a table.
+foreign import table
+  :: forall a
+   . a
+  -> Effect Unit
+
 -- | Start a named timer.
 foreign import time :: String -> Effect Unit
 


### PR DESCRIPTION
Hello maintainers,

I added a function, console.table

But you might be careful about the type definition. It's "forall a. a" because console.table function displays "tabular data" **as a table form**, like Object and Array (sorry I don't know the detail though), not just String.

It's so useful I think, but if I added Show type class constraint, it does not display **as a table form**...