### PR TITLE
Add IsLog type class

### DIFF
--- a/src/Effect/Console.js
+++ b/src/Effect/Console.js
@@ -1,27 +1,27 @@
 "use strict";
 
-exports.log = function (s) {
+exports._log = function (s) {
   return function () {
     console.log(s);
     return {};
   };
 };
 
-exports.warn = function (s) {
+exports._warn = function (s) {
   return function () {
     console.warn(s);
     return {};
   };
 };
 
-exports.error = function (s) {
+exports._error = function (s) {
   return function () {
     console.error(s);
     return {};
   };
 };
 
-exports.info = function (s) {
+exports._info = function (s) {
   return function () {
     console.info(s);
     return {};

--- a/src/Effect/Console.purs
+++ b/src/Effect/Console.purs
@@ -5,45 +5,66 @@ import Effect (Effect)
 import Data.Show (class Show, show)
 import Data.Unit (Unit)
 
+class IsLog a
+
+instance isLogString :: IsLog String
+instance isLogArray :: IsLog a => IsLog (Array a)
+
 -- | Write a message to the console.
-foreign import log
-  :: String
-  -> Effect Unit
+log :: forall a. IsLog a => a -> Effect Unit
+log = _log
 
 -- | Write a value to the console, using its `Show` instance to produce a
 -- | `String`.
 logShow :: forall a. Show a => a -> Effect Unit
 logShow a = log (show a)
 
--- | Write an warning to the console.
-foreign import warn
-  :: String
+foreign import _log
+  :: forall a
+   . a
   -> Effect Unit
+
+-- | Write an warning to the console.
+warn :: forall a. IsLog a => a -> Effect Unit
+warn = _warn
 
 -- | Write an warning value to the console, using its `Show` instance to produce
 -- | a `String`.
 warnShow :: forall a. Show a => a -> Effect Unit
 warnShow a = warn (show a)
 
--- | Write an error to the console.
-foreign import error
-  :: String
+foreign import _warn
+  :: forall a
+   . a
   -> Effect Unit
+
+-- | Write an error to the console.
+error :: forall a. IsLog a => a -> Effect Unit
+error = _error
 
 -- | Write an error value to the console, using its `Show` instance to produce a
 -- | `String`.
 errorShow :: forall a. Show a => a -> Effect Unit
 errorShow a = error (show a)
 
--- | Write an info message to the console.
-foreign import info
-  :: String
+foreign import _error
+  :: forall a
+   . a
   -> Effect Unit
+
+-- | Write an info message to the console.
+info :: forall a. IsLog a => a -> Effect Unit
+info = _info
 
 -- | Write an info value to the console, using its `Show` instance to produce a
 -- | `String`.
 infoShow :: forall a. Show a => a -> Effect Unit
 infoShow a = info (show a)
+
+foreign import _info
+  :: forall a
+   . a
+  -> Effect Unit
 
 -- | Start a named timer.
 foreign import time :: String -> Effect Unit


### PR DESCRIPTION
JS console functions typically handle logging of certain types in a special manner. For instance, logging Errors also display an accompanying stack trace. Logging dom elements on browsers can also emits a dom tree that can be interactively inspected.

Pointing to purescript-debug might not always suffice, since there are use cases outside of debugging -- for instance logging errors with stack traces on server side purescript.

I've read that there used to be `Any` variants (`logAny`, `warnAny`) that were `forall a. a -> Effect Unit`, but have been removed.

Perhaps aa middleground between accepting anything vs limiting logging only to strings is to simply mark which types make sense to be logged. So I introduced the typeclass `IsLog` here and an instance for String and Array. I'm open to renaming this. (Logging extra long arrays auto truncates the array and offers interactive expanding on browsers)

Another option is to keep `log` only for strings, but introduce `log'` which accepts others that have an `IsLog` instance.