### PR TITLE
Remove `return {}` for FFI functions

### DIFF
--- a/src/Effect/Console.js
+++ b/src/Effect/Console.js
@@ -3,53 +3,45 @@
 exports.log = function (s) {
   return function () {
     console.log(s);
-    return {};
   };
 };
 
 exports.warn = function (s) {
   return function () {
     console.warn(s);
-    return {};
   };
 };
 
 exports.error = function (s) {
   return function () {
     console.error(s);
-    return {};
   };
 };
 
 exports.info = function (s) {
   return function () {
     console.info(s);
-    return {};
   };
 };
 
 exports.time = function (s) {
   return function () {
     console.time(s);
-    return {};
   };
 };
 
 exports.timeLog = function (s) {
   return function () {
     console.timeLog(s);
-    return {};
   };
 };
 
 exports.timeEnd = function (s) {
   return function () {
     console.timeEnd(s);
-    return {};
   };
 };
 
 exports.clear = function () {
   console.clear();
-  return {};
 };


### PR DESCRIPTION
See [this Slack thread](https://functionalprogramming.slack.com/archives/C717K38CE/p1594507158478300) for some context.