### PR TITLE
Migrate FFI to ES modules

### DIFF
--- a/src/Effect/Console.js
+++ b/src/Effect/Console.js
@@ -1,47 +1,39 @@
 "use strict";
-
-exports.log = function (s) {
-  return function () {
-    console.log(s);
-  };
+export const log = function (s) {
+    return function () {
+        console.log(s);
+    };
 };
-
-exports.warn = function (s) {
-  return function () {
-    console.warn(s);
-  };
+export const warn = function (s) {
+    return function () {
+        console.warn(s);
+    };
 };
-
-exports.error = function (s) {
-  return function () {
-    console.error(s);
-  };
+export const error = function (s) {
+    return function () {
+        console.error(s);
+    };
 };
-
-exports.info = function (s) {
-  return function () {
-    console.info(s);
-  };
+export const info = function (s) {
+    return function () {
+        console.info(s);
+    };
 };
-
-exports.time = function (s) {
-  return function () {
-    console.time(s);
-  };
+export const time = function (s) {
+    return function () {
+        console.time(s);
+    };
 };
-
-exports.timeLog = function (s) {
-  return function () {
-    console.timeLog(s);
-  };
+export const timeLog = function (s) {
+    return function () {
+        console.timeLog(s);
+    };
 };
-
-exports.timeEnd = function (s) {
-  return function () {
-    console.timeEnd(s);
-  };
+export const timeEnd = function (s) {
+    return function () {
+        console.timeEnd(s);
+    };
 };
-
-exports.clear = function () {
-  console.clear();
+export const clear = function () {
+    console.clear();
 };


### PR DESCRIPTION
Changes all foreign modules to use ES modules instead of CJS.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
