### PR TITLE
Add group functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `group`, `groupCollapsed`, and `groupEnd` (#42 by @pete-murphy)
 
 Bugfixes:
 

--- a/src/Effect/Class/Console.purs
+++ b/src/Effect/Class/Console.purs
@@ -47,3 +47,12 @@ timeEnd = liftEffect <<< EffConsole.timeEnd
 
 clear :: forall m. MonadEffect m => m Unit
 clear = liftEffect EffConsole.clear
+
+group :: forall m. MonadEffect m => String -> m Unit
+group = liftEffect <<< EffConsole.group
+
+groupCollapsed :: forall m. MonadEffect m => String -> m Unit
+groupCollapsed = liftEffect <<< EffConsole.groupCollapsed
+
+groupEnd :: forall m. MonadEffect m => m Unit
+groupEnd = liftEffect EffConsole.groupEnd

--- a/src/Effect/Class/Console.purs
+++ b/src/Effect/Class/Console.purs
@@ -1,5 +1,6 @@
 module Effect.Class.Console where
 
+import Control.Bind (discard, bind, pure)
 import Data.Function ((<<<))
 import Data.Show (class Show)
 import Data.Unit (Unit)
@@ -56,3 +57,10 @@ groupCollapsed = liftEffect <<< EffConsole.groupCollapsed
 
 groupEnd :: forall m. MonadEffect m => m Unit
 groupEnd = liftEffect EffConsole.groupEnd
+
+grouped :: forall m a. MonadEffect m => String -> m a -> m a
+grouped name inner = do
+  group name
+  result <- inner
+  groupEnd
+  pure result

--- a/src/Effect/Console.js
+++ b/src/Effect/Console.js
@@ -49,3 +49,19 @@ export const timeEnd = function (s) {
 export const clear = function () {
   console.clear();
 };
+
+export const group = function (s) {
+  return function () {
+    console.group(s);
+  };
+};
+
+export const groupCollapsed = function (s) {
+  return function () {
+    console.groupCollapsed(s);
+  };
+};
+
+export const groupEnd = function () {
+  console.groupEnd();
+};

--- a/src/Effect/Console.purs
+++ b/src/Effect/Console.purs
@@ -66,3 +66,13 @@ foreign import timeEnd :: String -> Effect Unit
 
 -- | Clears the console
 foreign import clear :: Effect Unit
+
+-- | Creates a new inline group in the console. This indents following console
+-- | messages by an additional level, until `groupEnd` is called.
+foreign import group :: String -> Effect Unit
+
+-- | Same as `group`, but groups are collapsed by default.
+foreign import groupCollapsed :: String -> Effect Unit
+
+-- | Exits the current inline group in the console.
+foreign import groupEnd :: Effect Unit

--- a/src/Effect/Console.purs
+++ b/src/Effect/Console.purs
@@ -1,5 +1,6 @@
 module Effect.Console where
 
+import Control.Bind (discard, bind, pure)
 import Effect (Effect)
 
 import Data.Show (class Show, show)
@@ -76,3 +77,12 @@ foreign import groupCollapsed :: String -> Effect Unit
 
 -- | Exits the current inline group in the console.
 foreign import groupEnd :: Effect Unit
+
+-- | Perform an effect within the context of an inline group in the console.
+-- | Calls `group` and `groupEnd` before and after the effect, respectively.
+grouped :: forall a. String -> Effect a -> Effect a
+grouped name inner = do
+  group name
+  result <- inner
+  groupEnd
+  pure result

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -18,3 +18,5 @@ main = do
   Console.log "log in groupCollapsed"
   Console.groupEnd
   Console.groupEnd
+  Console.grouped "grouped" do 
+    Console.log "log in grouped"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,3 +12,9 @@ main = do
   Console.error "error"
   Console.info "info"
   Console.debug "debug"
+  Console.group "group"
+  Console.log "log in group"
+  Console.groupCollapsed "groupCollapsed"
+  Console.log "log in groupCollapsed"
+  Console.groupEnd
+  Console.groupEnd

--- a/test/expected_output.txt
+++ b/test/expected_output.txt
@@ -3,3 +3,7 @@ warn
 error
 info
 debug
+group
+  log in group
+  groupCollapsed
+    log in groupCollapsed

--- a/test/expected_output.txt
+++ b/test/expected_output.txt
@@ -7,3 +7,5 @@ group
   log in group
   groupCollapsed
     log in groupCollapsed
+grouped
+  log in grouped


### PR DESCRIPTION

**Description of the change**

Fixes #41. This adds `group`, `groupCollapsed`, and `groupEnd` functions. See MDN [Using groups in the console](https://developer.mozilla.org/en-US/docs/Web/API/console#using_groups_in_the_console).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
